### PR TITLE
Don't show 'in <categories>' for articles with no categories

### DIFF
--- a/site/templates/article.link.php
+++ b/site/templates/article.link.php
@@ -7,8 +7,8 @@
         <article class="post format_link">
         	<header class="post-meta">
                 <h1><a href="<?php echo $page->customlink() ?>"><?php echo html($page->linktitle()) ?></a></h1>
-                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time> in 
-                <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a>
+                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time>
+                <?php if ($page->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a> <?php } ?>
             </header>
             <div class="content">
 				<?php echo kirbytext($page->text()) ?>

--- a/site/templates/article.text.php
+++ b/site/templates/article.text.php
@@ -7,8 +7,8 @@
         <article class="post format_text">
         	<header class="post-meta">
                 <h1><?php echo html($page->title()) ?></h1>
-                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time> in 
-                <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a>
+                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time>
+                <?php if ($page->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a> <?php } ?>
             </header>
             <div class="content">
 				<?php echo kirbytext($page->text()) ?>

--- a/site/templates/article.video.php
+++ b/site/templates/article.video.php
@@ -6,8 +6,8 @@
 
         <article class="post format_video">
             <header class="post-meta">
-                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time> in 
-                <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a>
+                Posted on <time datetime="<?php echo $page->date('c') ?>"><?php echo $page->date('d.m.Y'); ?></time>
+                <?php if ($page->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $page->categories(); ?>"><?php echo $page->categories(); ?></a> <?php } ?>
             </header>
             <div class="content">
                 <?php echo kirbytext($page->video()) ?>

--- a/site/templates/blog.php
+++ b/site/templates/blog.php
@@ -28,8 +28,8 @@
         <article class="post format_text">
             <header class="post-meta">
                 <h1><a href="<?php echo $article->url() ?>"><?php echo html($article->title()) ?></a></h1>
-                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a>
+                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time>
+                <?php if ($article->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a> <?php } ?>
             </header>
             <p><?php echo excerpt($article->text(), 400) ?></p>
             <a class="read_more" href="<?php echo $article->url() ?>">read more →</a>
@@ -39,8 +39,8 @@
         <article class="post format_link">
             <header class="post-meta">
                 <h1><a href="<?php echo $article->customlink() ?>"><?php echo html($article->linktitle()) ?></a></h1>
-                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a>
+                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time>
+                <?php if ($article->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a> <?php } ?>
             </header>
             <?php echo kirbytext($article->text()) ?>
             <a class="read_more" href="<?php echo $article->url() ?>">permalink</a>
@@ -49,8 +49,8 @@
         <?php elseif($article->template() == 'article.video'): /*** post format: VIDEO ***/ ?>
         <article class="post format_video">
             <header class="post-meta">
-                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a>
+                Posted on <time datetime="<?php echo $article->date('c') ?>"><?php echo $article->date('d.m.Y'); ?></time>
+                <?php if ($article->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $article->categories(); ?>"><?php echo $article->categories(); ?></a> <?php } ?>
             </header>
             <?php echo kirbytext($article->video()) ?>
             <?php echo kirbytext($article->text()) ?>

--- a/site/templates/search.php
+++ b/site/templates/search.php
@@ -32,8 +32,8 @@
         <article class="post format_text">
             <header class="post-meta">
                 <h1><a href="<?php echo $result->url() ?>"><?php echo html($result->title()) ?></a></h1>
-                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a>
+                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time>
+                <?php if ($result->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a> <?php } ?>
             </header>
             <p><?php echo excerpt($result->text(), 400) ?></p>
             <a class="read_more" href="<?php echo $result->url() ?>">read more →</a>
@@ -43,8 +43,8 @@
         <article class="post format_link">
             <header class="post-meta">
                 <h1><a href="<?php echo $result->customlink() ?>"><?php echo html($result->linktitle()) ?></a></h1>
-                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a>
+                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time>
+                <?php if ($result->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a> <?php } ?>
             </header>
             <?php echo kirbytext($result->text()) ?>
             <a class="read_more" href="<?php echo $result->url() ?>">permalink</a>
@@ -53,8 +53,8 @@
         <?php elseif($result->template() == 'article.video'): /*** post format: VIDEO ***/ ?>
         <article class="post format_video">
             <header class="post-meta">
-                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time> in
-                <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a>
+                Posted on <time datetime="<?php echo $result->date('c') ?>"><?php echo $result->date('d.m.Y'); ?></time>
+                <?php if ($result->categories()) { ?> in <a class="category" href="<?php echo url() ?>category:<?php echo $result->categories(); ?>"><?php echo $result->categories(); ?></a> <?php } ?>
             </header>
             <?php echo kirbytext($result->video()) ?>
             <?php echo kirbytext($result->text()) ?>


### PR DESCRIPTION
With this patch articles with no categories don't get a spurious "in " when there are no categories to show for the article.
