### PR TITLE
fix filtering of categories with spaces in their names

### DIFF
--- a/site/templates/blog.php
+++ b/site/templates/blog.php
@@ -5,14 +5,17 @@
 	<main role="main">
         <?php if(param('category')) {   /*** article overview ***/
 
+            $category = param('category');
+            $category = str_replace('+', ' ', $category);
+            $category = str_replace('%20', ' ', $category);
             $articles = $pages->find('blog')
                             ->children()
                             ->visible()
-                            ->filterBy('categories', param('category'), ',')
+                            ->filterBy('categories', $category, ',')
                             ->flip()
                             ->paginate(4);
 
-                            echo ('<h1 class="results">Category Archives: <em>'), (param('category')), ('</em></h1>');
+                            echo ('<h1 class="results">Category Archives: <em>'), ($category), ('</em></h1>');
             } else {
 
             $articles = $pages->find('blog')


### PR DESCRIPTION
- Without this, categories, specified as parameters on the URL will
  get either +'s or %20's in their names and will never match
  the category filter. As a result, no posts are shown.
