### PR TITLE
Removing stray </a> tag

### DIFF
--- a/site/snippets/footer.php
+++ b/site/snippets/footer.php
@@ -1,5 +1,5 @@
   <footer class="site-footer" role="contentinfo">
-    <?php echo kirbytext($site->info()) ?></a>
+    <?php echo kirbytext($site->info()) ?>
   </footer>
 
 </body>


### PR DESCRIPTION
The W3C validator threw an error at this stray </a> tag.
